### PR TITLE
Update isort hook to use official repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
     hooks:
     -   id: flake8                  # a command-line utility for enforcing style consistency across Python projects
 
--   repo: https://github.com/doublify/pre-commit-isort
-    rev: v4.3.0
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.4.2
     hooks:
     -   id: isort                   # Sort and organize Python imports
-        args: [ -m 2, -l 100 ]
+        args: [ -m=3, -tc, -l 100 ]


### PR DESCRIPTION
Moving from the deprecated isort hook repository to use the official
isort repository instead. Also making isort compatible with black.

Signed-off-by: Filipe Utzig <filipeutzig@gmail.com>