### PR TITLE
Fix Docker image build for new isort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /prv
 RUN apk update && \
     apk upgrade && \
     apk add --no-cache git && \
-    apk add --no-cache --virtual .build-deps build-base && \
+    apk add --no-cache --virtual .build-deps build-base libffi-dev openssl-dev && \
+    pip3 install --upgrade pip && \
     pip3 install pre-commit && \
     pre-commit install-hooks && \
     apk del .build-deps


### PR DESCRIPTION
The new isort version depends on libffi-dev and openssl-dev to build
and this was causing a crash on Docker image build.

Also updating pip version.

Signed-off-by: Filipe Utzig <filipeutzig@gmail.com>